### PR TITLE
Made the renderer build on UT 469

### DIFF
--- a/Src/UnComputeShader.cpp
+++ b/Src/UnComputeShader.cpp
@@ -66,7 +66,9 @@ struct FActorLightCommon
 	INT				Pad[2];
 };
 
+#if DX11_HP2
 static Sizer<sizeof(FLightingData)> DaSize;
+#endif
 
 FTransTexture* UD3D11RenderDevice::InitMeshComputeShader(INT VertCount)
 {

--- a/Src/UnConfig.cpp
+++ b/Src/UnConfig.cpp
@@ -45,6 +45,7 @@ void UD3D11RenderDevice::StaticConstructor()
 	PrefersDeferredLoad = 0;
 	SupportsTC			= 1;
 
+#if DX11_HP2
 	bSupportsTwoSided	= 0;
 
 	// Metallicafan212:	HP2 Rendertarget textures
@@ -52,6 +53,7 @@ void UD3D11RenderDevice::StaticConstructor()
 
 	// Metallicafan212:	HP2 native wireframe
 	bSupportsNativeWireframe = 1;
+#endif
 
 	if (!GConfig->GetBool(ClsName, TEXT("DetailTextures"), (UBOOL&)DetailTextures))
 	{
@@ -174,7 +176,7 @@ void UD3D11RenderDevice::ClampUserOptions()
 	}
 
 	// Metallicafan212:	We have the final clamp
-	NumAASamples = Clamp(NumAASamples, 1, SampleCount);
+	NumAASamples = Clamp(NumAASamples, 1, static_cast<INT>(SampleCount));
 
 	// Metallicafan212:	Now make sure it's the lower of the request (if it's odd)
 	//					TODO! Rewrite this, if the user specifies 6, we return 8 due to the mod 2 not working since 6 isn't odd

--- a/Src/UnD3D11Drv.cpp
+++ b/Src/UnD3D11Drv.cpp
@@ -473,7 +473,7 @@ UBOOL UD3D11RenderDevice::Init(UViewport* InViewport, INT NewX, INT NewY, INT Ne
 
 	// Metallicafan212:	These are all supported by DX11.1
 	//					In the future, I will query for support (or use the DX feature level???)
-	RegisterTextureFormat(TEXF_DXT1, DXGI_FORMAT_BC1_UNORM, 0, 8, &FD3DTexType::BlockCompressionPitch);
+	RegisterTextureFormat(TEXF_DXT1, DXGI_FORMAT_BC1_UNORM_SRGB, 0, 8, &FD3DTexType::BlockCompressionPitch);
 
 	RegisterTextureFormat(TEXF_DXT3, DXGI_FORMAT_BC2_UNORM, 0, 16, &FD3DTexType::BlockCompressionPitch);
 

--- a/Src/UnHPCustom.cpp
+++ b/Src/UnHPCustom.cpp
@@ -10,13 +10,20 @@ void UDX11RenderTargetTexture::Lock(FTextureInfo& Info, FTime InTime, INT LOD, U
 	guard(UDX11RenderTargetTexture::Lock);
 
 	// Metallicafan212:	Copy HP2 specific info
+#if DX11_HP2
 	Info.MaskedColor		= MaskedColor;
 	Info.GranularityColor	= MaskedGranularity;
+#endif
 
 	// Metallicafan212:	Setup the common vars
 	Info.Texture			= this;
+#if DX11_HP2
 	Info.UScale				= DrawScale;
 	Info.VScale				= DrawScale;
+#else
+	Info.UScale				= 1.f;
+	Info.VScale				= 1.f;
+#endif
 
 	// Metallicafan212:	TODO! Probably don't need any of these
 	/*
@@ -35,7 +42,11 @@ void UDX11RenderTargetTexture::Lock(FTextureInfo& Info, FTime InTime, INT LOD, U
 	Info.NumMips			= 0;
 
 	// Metallicafan212:	Matches the GPU side
+#if DX11_UT_469
+	Info.Format				= TEXF_BGRA8;
+#else
 	Info.Format				= TEXF_RGBA8;
+#endif
 
 	// Metallicafan212:	TODO! Cache ID is probably not needed!
 	//Info.CacheID			= MakeCacheID((ECacheIDBase)(CID_RenderTexture), this);
@@ -52,11 +63,19 @@ void UDX11RenderTargetTexture::Lock(FTextureInfo& Info, FTime InTime, INT LOD, U
 
 	// Metallicafan212:	TODO! Should we even update???
 	if (InTime != 0.f)
+	{
+#if DX11_HP2
 		Update(InTime, RenDev != nullptr ? RenDev->Viewport : nullptr);
+#else
+		Update(InTime);
+#endif
+	}
 
 	// Metallicafan212:	Give it the bits
+#if DX11_HP2
 	Info.UBits				= UBits;
 	Info.VBits				= VBits;
+#endif
 
 	// Success.
 	unguardobj;
@@ -112,6 +131,7 @@ void ReplaceInText(FString& In, const TCHAR* Match, const TCHAR* With)
 	unguard;
 }
 
+#if DX11_HP2
 int UD3D11RenderDevice::DrawString(QWORD Flags, UFont* Font, INT& DrawX, INT& DrawY, const TCHAR* Text, const FPlane& Color, FLOAT Scale, FLOAT SpriteScaleX, FLOAT SpriteScaleY)
 {
 	guard(UD3D11RenderDevice::DrawString);
@@ -313,6 +333,7 @@ int UD3D11RenderDevice::DrawString(QWORD Flags, UFont* Font, INT& DrawX, INT& Dr
 
 	unguard;
 }
+#endif
 
 // Metallicafan212:	Viewer-based zone fog
 void UD3D11RenderDevice::SetDistanceFog(UBOOL Enable, FLOAT FogStart, FLOAT FogEnd, FPlane Color, FLOAT FadeRate)
@@ -450,14 +471,20 @@ UTexture* UD3D11RenderDevice::CreateRenderTargetTexture(INT W, INT H, UBOOL bCre
 	guard(UD3D11RenderDevice::CreateRenderTargetTexture);
 
 	// Metallicafan212:	Create the texture
+#if DX11_HP2
 	UDX11RenderTargetTexture* Tex = ConstructObject<UDX11RenderTargetTexture>(GetTransientPackage(), NAME_None, RF_Transient);
+#else
+	UDX11RenderTargetTexture* Tex = ConstructObject<UDX11RenderTargetTexture>(UDX11RenderTargetTexture::StaticClass(), GetTransientPackage(), NAME_None, RF_Transient);
+#endif
 
 	if (Tex != nullptr)
 	{
 		// Metallicafan212:	Set the vars
 		Tex->USize		= Tex->UClamp = W;
 		Tex->VSize		= Tex->VClamp = H;
+#if DX11_HP2
 		Tex->DrawScale	= 1.0f;
+#endif
 
 		Tex->D3DDev		= this;
 

--- a/Src/UnHitTesting.cpp
+++ b/Src/UnHitTesting.cpp
@@ -16,7 +16,11 @@ void UD3D11RenderDevice::PushHit(const BYTE* Data, INT Count)
 	HHitProxy* Hit = (HHitProxy*)Data;
 
 	// Metallicafan212:	Ask it for the priority, brushes and gizmos have higher priority
+#if DX11_HP2
 	Info.Priority = Hit->GetPriority();
+#else
+	Info.Priority = 1;
+#endif
 
 	if (PixelTopIndex != -1)
 	{
@@ -31,7 +35,7 @@ void UD3D11RenderDevice::PushHit(const BYTE* Data, INT Count)
 
 	// Metallicafan212:	Keep this hit info in the hit
 	Info.HitData.Add(Count);
-	appMemcpy(&Info.HitData[0], Data, Count);
+	appMemcpy(&Info.HitData(0), Data, Count);
 
 	// Metallicafan212:	Now push it onto our local stack
 	PixelHitInfo.AddItem(Info);
@@ -49,7 +53,7 @@ void UD3D11RenderDevice::PopHit(INT Count, UBOOL bForce)
 
 	EndBuffering();
 
-	FPixHitInfo* Info = &PixelHitInfo[PixelTopIndex];
+	FPixHitInfo* Info = &PixelHitInfo(PixelTopIndex);
 
 	if (Info->Prev != -1)
 	{
@@ -240,7 +244,7 @@ void UD3D11RenderDevice::DetectPixelHit()
 				}
 
 				// Metallicafan212:	Priority is done when the hit is pushed
-				HitAppear.Set(Temp.Int4, *Val + PixelHitInfo[Temp.Int4].Priority);
+				HitAppear.Set(Temp.Int4, *Val + PixelHitInfo(Temp.Int4).Priority);
 			}
 		}
 	}
@@ -280,27 +284,27 @@ void UD3D11RenderDevice::DetectPixelHit()
 		// Metallicafan212:	Unwind the hit info, from the top
 		TArray<FPixHitInfo*> Parents;
 
-		FPixHitInfo* Top = &PixelHitInfo[BiggestHit];
+		FPixHitInfo* Top = &PixelHitInfo(BiggestHit);
 
 		// Metallicafan212:	Go until we hit the topmost parent
 		while (Top != nullptr)
 		{
 			Parents.Insert(0);
-			Parents[0] = Top;
+			Parents(0) = Top;
 
 			// Metallicafan212:	Break out if the parent is invalid
 			if (Top->Prev == -1)
 				Top = nullptr;
 			else
-				Top = &PixelHitInfo[Top->Prev];
+				Top = &PixelHitInfo(Top->Prev);
 		}
 
 		// Metallicafan212:	Copy in order to preserve heiarchy
 		for (INT i = 0; i < Parents.Num(); i++)
 		{
-			appMemcpy(Data, &(Parents[i]->HitData[0]), Parents[i]->HitData.Num());
-			Data += Parents[i]->HitData.Num();
-			m_HitCount += Parents[i]->HitData.Num();
+			appMemcpy(Data, &(Parents(i)->HitData(0)), Parents(i)->HitData.Num());
+			Data += Parents(i)->HitData.Num();
+			m_HitCount += Parents(i)->HitData.Num();
 		}
 	}
 

--- a/Src/UnSurf.cpp
+++ b/Src/UnSurf.cpp
@@ -44,8 +44,14 @@ inline void BufferAndIndex(FSurfaceFacet& Facet, FPlane Color, FD3DVert* m_Verte
 }
 
 // Metallicafan212:	Definitions relating to complex surface (BSP) drawing
+#if DX11_HP2
 void UD3D11RenderDevice::DrawComplexSurface(FSceneNode* Frame, FSurfaceInfo& Surface, FSurfaceFacet& Facet, QWORD PolyFlags, BYTE cAlpha)
 {
+#else
+void UD3D11RenderDevice::DrawComplexSurface(FSceneNode* Frame, FSurfaceInfo& Surface, FSurfaceFacet& Facet)
+{
+	DWORD PolyFlags = Surface.PolyFlags;
+#endif
 	guard(UD3D11RenderDevice::DrawComplexSurface);
 
 	// Metallicafan212:	This breaks mirrors, we HAVE to render invisible surfaces....

--- a/Src/UnTiles.cpp
+++ b/Src/UnTiles.cpp
@@ -1,7 +1,11 @@
 #include "D3D11Drv.h"
 
 // Metallicafan212:	Definitions for tile-related functions
+#if DX11_HP2
 void UD3D11RenderDevice::DrawTile(FSceneNode* Frame, FTextureInfo& Info, FLOAT X, FLOAT Y, FLOAT XL, FLOAT YL, FLOAT U, FLOAT V, FLOAT UL, FLOAT VL, FSpanBuffer* Span, FLOAT Z, FPlane Color, FPlane Fog, QWORD PolyFlags)
+#else
+void UD3D11RenderDevice::DrawTile(FSceneNode* Frame, FTextureInfo& Info, FLOAT X, FLOAT Y, FLOAT XL, FLOAT YL, FLOAT U, FLOAT V, FLOAT UL, FLOAT VL, FSpanBuffer* Span, FLOAT Z, FPlane Color, FPlane Fog, DWORD PolyFlags)
+#endif
 {
 	guard(UD3D11RenderDevice::DrawTile);
 
@@ -193,6 +197,7 @@ void UD3D11RenderDevice::DrawTile(FSceneNode* Frame, FTextureInfo& Info, FLOAT X
 	unguard;
 }
 
+#if DX11_HP2
 void UD3D11RenderDevice::DrawRotatedTile(FSceneNode* Frame, FTextureInfo& Info, FLOAT X, FLOAT Y, FLOAT XL, FLOAT YL, FLOAT U, FLOAT V, FLOAT UL, FLOAT VL, FSpanBuffer* Span, FLOAT Z, FPlane Color, FPlane Fog, QWORD PolyFlags, FCoords InCoords)
 {
 	// Metallicafan212: We call the original version, but tell it to not reset the coord or bool state
@@ -203,3 +208,4 @@ void UD3D11RenderDevice::DrawRotatedTile(FSceneNode* Frame, FTextureInfo& Info, 
 	FTileShader->TileCoords			= InCoords;
 	DrawTile(Frame, Info, X, Y, XL, YL, U, V, UL, VL, Span, Z, Color, Fog, PolyFlags | PF_Memorized);
 }
+#endif


### PR DESCRIPTION
This PR includes a bunch of changes:
* The renderer now builds on UT 469 and supports the OldUnreal469 renderer interface
* Fixed some undefined behavior (e.g., delete[] on a void pointer, assignment of a string literal to a TCHAR*)
* Switched to the () operator for TArray accesses because most UE1 games don't support [] on TArrays
* Switched to ARRAYSIZE to calculate the size of statically allocated array (because std::size requires C++17 or later)
* Made some casts explicit
* Switched to the vanilla UE1 version of ConstructObject (except for HP2)
* ifdef'ed out some more HP2-specific code
* Added a GetMipDataAndSize to support the texture uploading and conversion code. Currently, this only supports HP2 and UT 469, but it should be fairly easy to add support for other games

The renderer now builds on UT 469, but has a ton of issues:
* DrawComplexSurface doesn't seem to work at all. None of the BSP renders
* DrawTile has some alignment issues. On the screenshot below, you can see that the menu text is misaligned
![afbeelding](https://github.com/metallicafan212/D3D11Drv/assets/10390414/6b3dfee0-d5ec-4909-8035-ce69d649724a)
* Some tiles are completely corrupted, but this should be easy to figure out:
![afbeelding](https://github.com/metallicafan212/D3D11Drv/assets/10390414/f41bbfd4-e1c7-4dbb-8706-67b10d9f094b)
* Meshes have some depth issues. This is probably a UT 469 DrawGouraudTriangles-specific problem:
![afbeelding](https://github.com/metallicafan212/D3D11Drv/assets/10390414/35941262-4246-4a14-af4b-3647bf93ec0e)
