### PR TITLE
Clamp minSize to 4, only on BC* textures (fix broken textures)

### DIFF
--- a/Src/UnTexture.cpp
+++ b/Src/UnTexture.cpp
@@ -256,8 +256,9 @@ void UICBINDx11RenderDevice::UpdateTextureRect(FTextureInfo& Info, INT U, INT V,
 
 	if (m_FeatureLevel != D3D_FEATURE_LEVEL_11_1)
 	{
-		DaTex->USize	= Clamp(DaTex->USize, 4, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
-		DaTex->VSize	= Clamp(DaTex->VSize, 4, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+		INT MinSize = Info.Format == TEXF_BC1 || (Info.Format >= TEXF_BC2 && Info.Format <= TEXF_BC6H) ? 4 : 0;
+		DaTex->USize	= Clamp(DaTex->USize, MinSize, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+		DaTex->VSize	= Clamp(DaTex->VSize, MinSize, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
 	}
 	
 	DaTex->CacheID		= CacheID;
@@ -319,8 +320,9 @@ void UICBINDx11RenderDevice::CacheTextureInfo(FTextureInfo& Info, FPLAG PolyFlag
 
 	if (m_FeatureLevel != D3D_FEATURE_LEVEL_11_1)
 	{
-		DaTex->USize	= Clamp(DaTex->USize, 4, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
-		DaTex->VSize	= Clamp(DaTex->VSize, 4, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+		INT MinSize = Info.Format == TEXF_BC1 || (Info.Format >= TEXF_BC2 && Info.Format <= TEXF_BC6H) ? 4 : 0;
+		DaTex->USize	= Clamp(DaTex->USize, MinSize, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
+		DaTex->VSize	= Clamp(DaTex->VSize, MinSize, D3D11_REQ_TEXTURE2D_U_OR_V_DIMENSION);
 	}
 	
 	//DaTex->UMult		= 1.0f / (Info.UScale * Info.USize);


### PR DESCRIPTION
Before:
![scr_1689960760](https://github.com/metallicafan212/ICBINDx11Drv/assets/70026933/45de7d22-bf7a-4060-83a9-0102afd1f60d)
After:
![scr_1689961377](https://github.com/metallicafan212/ICBINDx11Drv/assets/70026933/f33a7da7-2b1e-4fb7-a48a-892a95934269)
Also solve rainbow lightmaps:
![scr_1689961626](https://github.com/metallicafan212/ICBINDx11Drv/assets/70026933/38c95fa9-f8ea-4ea9-9f58-343c83c33763)
